### PR TITLE
Allow zoned decimal items to be up to 31 digits in length + Removal of "DB2 via VSAM" feature 

### DIFF
--- a/plugins/genevagui/src/com/ibm/safr/we/constants/Codes.java
+++ b/plugins/genevagui/src/com/ibm/safr/we/constants/Codes.java
@@ -47,9 +47,6 @@ public class Codes {
 	public static final int VSAM_ORDERED = 3;
 	/** ACCMETHOD of type DB2 via SQL. */
 	public static final int DB2VIASQL = 6;
-	/** ACCMETHOD of type DB2 via VSAM. */
-	public static final int DB2VIAVSAM = 7;
-
 	/** DATATYPE of type Alphanumeric. */
 	public static final int ALPHANUMERIC = 1;
 	/** DATATYPE of type Zoned Decimal. */
@@ -521,12 +518,6 @@ public class Codes {
         db2sq.setCodeDescription("DB2 via SQL");
         db2sq.setCodeValue("DB2SQ");
         transfers.add(db2sq);
-
-        CodeTransfer db2vs = new CodeTransfer();
-        db2vs.setGeneralId(DB2VIAVSAM);
-        db2vs.setCodeDescription("DB2 via VSAM");
-        db2vs.setCodeValue("DB2VS");
-        transfers.add(db2vs);
         
         return new CodeSet(CodeCategories.ACCMETHOD, transfers);        
     }

--- a/plugins/genevagui/src/com/ibm/safr/we/model/SAFRValidator.java
+++ b/plugins/genevagui/src/com/ibm/safr/we/model/SAFRValidator.java
@@ -179,11 +179,11 @@ public class SAFRValidator {
 			int generalId = dataType.getGeneralId().intValue();
 			switch (generalId) {
 			case Codes.ZONED_DECIMAL:
-				if ((length < 1) || (length > 16)) {
+				if ((length < 1) || (length > 31)) {
 					validationException
 							.setErrorMessage(
 									Property.DATATYPE,
-									"Data type errors: Zoned Decimal must have minimum length of 1 and maximum length of 16(inclusive).");
+									"Data type errors: Zoned Decimal must have minimum length of 1 and maximum length of 31(inclusive).");
 
 				}
 				break;

--- a/plugins/genevagui/src/com/ibm/safr/we/model/diff/DiffPhysicalFile.java
+++ b/plugins/genevagui/src/com/ibm/safr/we/model/diff/DiffPhysicalFile.java
@@ -79,8 +79,7 @@ public class DiffPhysicalFile extends DiffNodeComp {
         // process SQL information
         Integer lhsAccess = lhs.getAccessMethodCode().getGeneralId();
         Integer rhsAccess = rhs.getAccessMethodCode().getGeneralId();
-        if ((lhsAccess == Codes.DB2VIASQL || lhsAccess == Codes.DB2VIAVSAM) ||
-            (rhsAccess == Codes.DB2VIASQL || rhsAccess == Codes.DB2VIAVSAM)) {
+        if (lhsAccess == Codes.DB2VIASQL || rhsAccess == Codes.DB2VIASQL) {
             sql = new DiffNodeSection();        
             sql.setName("SQL"); 
             sql.setParent(this);
@@ -159,8 +158,7 @@ public class DiffPhysicalFile extends DiffNodeComp {
         // process Dataset information
         Integer lhsAccess = lhs.getAccessMethodCode().getGeneralId();
         Integer rhsAccess = rhs.getAccessMethodCode().getGeneralId();
-        if ((lhsAccess != Codes.DB2VIASQL && lhsAccess != Codes.DB2VIAVSAM) ||
-            (rhsAccess != Codes.DB2VIASQL && rhsAccess != Codes.DB2VIAVSAM)) {
+        if (lhsAccess != Codes.DB2VIASQL || rhsAccess != Codes.DB2VIASQL) {
             dataset = new DiffNodeSection();        
             dataset.setName("Dataset"); 
             dataset.setParent(this);

--- a/plugins/genevagui/src/com/ibm/safr/we/model/diff/NodePhysicalFile.java
+++ b/plugins/genevagui/src/com/ibm/safr/we/model/diff/NodePhysicalFile.java
@@ -70,7 +70,7 @@ public class NodePhysicalFile extends DiffNodeComp {
         DiffNode dataset = null;
         // process Dataset information
         Integer lhsAccess = pf.getAccessMethodCode().getGeneralId();
-        if ((lhsAccess != Codes.DB2VIASQL && lhsAccess != Codes.DB2VIAVSAM)) {
+        if (lhsAccess != Codes.DB2VIASQL) {
             dataset = new DiffNodeSection();        
             dataset.setName("Dataset"); 
             dataset.setParent(this);
@@ -92,7 +92,7 @@ public class NodePhysicalFile extends DiffNodeComp {
         DiffNodeSection sql = null;
         // process SQL information
         Integer access = pf.getAccessMethodCode().getGeneralId();
-        if ((access == Codes.DB2VIASQL || access == Codes.DB2VIAVSAM)) {
+        if (access == Codes.DB2VIASQL) {
             sql = new DiffNodeSection();        
             sql.setName("SQL");            
             PhysicalFile.SQLDatabase sqlDb = pf.new SQLDatabase();            

--- a/plugins/genevagui/src/com/ibm/safr/we/ui/editors/pf/PhysicalFileDatabaseEditor.java
+++ b/plugins/genevagui/src/com/ibm/safr/we/ui/editors/pf/PhysicalFileDatabaseEditor.java
@@ -61,12 +61,7 @@ public class PhysicalFileDatabaseEditor {
     private Text textSQL;
     private Text textSQLDDName;
     
-    private Section sectionVSAM;
-    private Composite compositeVSAM;
-    private Text textVSAMSchema;
-    private Text textVSAMTable;
-    private Combo comboVSAMRowFormat;
-    private Button checkVSAMNull;
+    
     
     private String selectedRowFormat = "";
     
@@ -112,7 +107,6 @@ public class PhysicalFileDatabaseEditor {
         });
         
         createSectionSQL();
-  //      createSectionVSAM();
         
         return compositeDB2;
         
@@ -183,119 +177,6 @@ public class PhysicalFileDatabaseEditor {
         });
         
     }
-
-    private void createSectionVSAM() {
-        sectionVSAM = mediator.getSAFRToolkit().createSection(compositeDB2, Section.TITLE_BAR, "DB2 via VSAM");
-        sectionVSAM.setLayout(new FormLayout());
-        FormData dataSectionDetails = new FormData();
-        dataSectionDetails.top = new FormAttachment(sectionSQL, 10);
-        dataSectionDetails.bottom = new FormAttachment(100, 0);
-        sectionVSAM.setLayoutData(dataSectionDetails);        
-        
-        compositeVSAM = mediator.getSAFRToolkit().createComposite(sectionVSAM, SWT.NONE);
-        compositeVSAM.setLayout(new FormLayout());
-        sectionVSAM.setClient(compositeVSAM);   
-        
-        Label labelSchema = mediator.getSAFRToolkit().createLabel(compositeVSAM,SWT.NONE, "&Schema:");
-        FormData labelSchemaData = new FormData();
-        labelSchemaData.top = new FormAttachment(0, 10);
-        labelSchemaData.left = new FormAttachment(0, 20);
-        labelSchema.setLayoutData(labelSchemaData);
-        
-        textVSAMSchema = mediator.getSAFRToolkit().createTextBox(compositeVSAM, SWT.NONE);
-        textVSAMSchema.setData(SAFRLogger.USER, "DB2 Schema"); 
-        FormData textVSAMSchemaData = new FormData();
-        textVSAMSchemaData.top = new FormAttachment(0, 10);
-        textVSAMSchemaData.left = new FormAttachment(labelSchema, 110);
-        textVSAMSchemaData.width = 300;
-        textVSAMSchema.setLayoutData(textVSAMSchemaData);
-        textVSAMSchema.setTextLimit(MAXSCHEMA);
-        textVSAMSchema.addModifyListener(new ModifyListener() {
-            @Override
-            public void modifyText(ModifyEvent e) {
-                
-                Code accessMethod = physicalFile.getAccessMethodCode();
-                if (accessMethod.getGeneralId().equals(Codes.DB2VIAVSAM) && 
-                    !UIUtilities.isEqualString(pfSql.getSchema(), textVSAMSchema.getText())) {
-                    mediator.setDirty(true);
-                    pfSql.setSchema(textVSAMSchema.getText());
-                }
-            }
-        });
-
-        Label labelTable = mediator.getSAFRToolkit().createLabel(compositeVSAM,SWT.NONE, "&Table Name:");
-        FormData labelTableData = new FormData();
-        labelTableData.top = new FormAttachment(labelSchema, 10);
-        labelTableData.left = new FormAttachment(0, 20);
-        labelTable.setLayoutData(labelTableData);
-        
-        textVSAMTable = mediator.getSAFRToolkit().createTextBox(compositeVSAM, SWT.NONE);
-        textVSAMTable.setData(SAFRLogger.USER, "DB2 Table"); 
-        FormData textVSAMTableData = new FormData();
-        textVSAMTableData.top = new FormAttachment(labelSchema, 10);
-        textVSAMTableData.left = new FormAttachment(labelSchema, 110);
-        textVSAMTableData.width = 300;
-        textVSAMTable.setLayoutData(textVSAMTableData);
-        textVSAMTable.setTextLimit(MAXTABLENAME);
-        textVSAMTable.addModifyListener(new ModifyListener() {
-            @Override
-            public void modifyText(ModifyEvent e) {
-                
-                Code accessMethod = physicalFile.getAccessMethodCode();
-                if (accessMethod.getGeneralId().equals(Codes.DB2VIAVSAM) && 
-                    !UIUtilities.isEqualString(pfSql.getTableName(), textVSAMTable.getText())) {
-                    mediator.setDirty(true);
-                    pfSql.setTableName(textVSAMTable.getText());
-                }
-            }
-        });
-        
-        Label labelSQLRowFormat = mediator.getSAFRToolkit().createLabel(compositeVSAM, SWT.NONE, "Row &Format:");
-        FormData labelSQLRowFormatData = new FormData();
-        labelSQLRowFormatData.top = new FormAttachment(labelTable, 10);
-        labelSQLRowFormatData.left = new FormAttachment(0, 20);
-        labelSQLRowFormat.setLayoutData(labelSQLRowFormatData);
-        
-        comboVSAMRowFormat = mediator.getSAFRToolkit().createComboBox(compositeVSAM, SWT.READ_ONLY, "");
-        comboVSAMRowFormat.setData(SAFRLogger.USER, "SQL Row Format");
-        FormData comboVSAMRowFormatData = new FormData();
-        comboVSAMRowFormatData.top = new FormAttachment(labelTable, 10);
-        comboVSAMRowFormatData.left = new FormAttachment(labelSchema, 110);
-        comboVSAMRowFormat.setLayoutData(comboVSAMRowFormatData);
-        UIUtilities.populateComboBox(comboVSAMRowFormat, CodeCategories.DBMSROWFMT,-1, true);
-        comboVSAMRowFormat.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                Code accessMethod = physicalFile.getAccessMethodCode();
-                if (accessMethod.getGeneralId().equals(Codes.DB2VIAVSAM) && 
-                    !(comboVSAMRowFormat.getText().equals(selectedRowFormat))) {
-                    mediator.setDirty(true);
-                    selectedRowFormat = comboVSAMRowFormat.getText();
-                    Code rowFormat = UIUtilities.getCodeFromCombo(comboVSAMRowFormat);
-                    if (rowFormat != null) {
-                        pfSql.setRowFormatCode(rowFormat);
-                    }
-                }
-            }
-        });
-        
-        checkVSAMNull = mediator.getSAFRToolkit().createCheckBox(compositeVSAM, "Return N&ull Ind");
-        checkVSAMNull.setData(SAFRLogger.USER, "SQL Return Null Ind");            
-        FormData checkVSAMNullData = new FormData();
-        checkVSAMNullData.top = new FormAttachment(labelTable, 10);
-        checkVSAMNullData.left = new FormAttachment(comboVSAMRowFormat, 10);
-        checkVSAMNull.setLayoutData(checkVSAMNullData);
-        checkVSAMNull.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                Code accessMethod = physicalFile.getAccessMethodCode();
-                if (accessMethod.getGeneralId().equals(Codes.DB2VIAVSAM)) { 
-                    pfSql.setIncludeNullIndicators(checkVSAMNull.getSelection());
-                    mediator.setDirty(true);
-                }
-            }
-        });
-    }    
     
     protected void doRefreshControls() {        
         UIUtilities.checkNullText(textSubsystem, pfSql.getSubSystem());
@@ -309,20 +190,7 @@ public class PhysicalFileDatabaseEditor {
 //            comboVSAMRowFormat.setText("");
             selectedRowFormat = "";
 //            checkVSAMNull.setSelection(false);           
-        } else if (accessMethod.getGeneralId().equals(Codes.DB2VIAVSAM)) {
-            textSQLDDName.setText("");
-            textSQL.setText("");
-            UIUtilities.checkNullText(textVSAMSchema, pfSql.getSchema());
-            UIUtilities.checkNullText(textVSAMTable, pfSql.getTableName());
-            UIUtilities.checkNullCombo(comboVSAMRowFormat, pfSql.getRowFormatCode());
-            if (pfSql.getRowFormatCode() != null) {
-                comboVSAMRowFormat.setText(pfSql.getRowFormatCode().getDescription());
-            } else {
-                comboVSAMRowFormat.setText("");
-            }            
-            selectedRowFormat = comboVSAMRowFormat.getText();
-            checkVSAMNull.setSelection(pfSql.isIncludeNullIndicators());
-        }
+        } 
     }
 
 
@@ -335,14 +203,5 @@ public class PhysicalFileDatabaseEditor {
 //        checkVSAMNull.setEnabled(false);        
     }
 
-    protected void enableVSAM() {
-        textSQLDDName.setEnabled(false);
-        textSQL.setEnabled(false);
-        textVSAMSchema.setEnabled(true);
-        textVSAMTable.setEnabled(true);
-        comboVSAMRowFormat.setEnabled(true);
-        checkVSAMNull.setEnabled(true);        
-        
-    }
     
 }

--- a/plugins/genevagui/src/com/ibm/safr/we/ui/editors/pf/PhysicalFileGeneralEditor.java
+++ b/plugins/genevagui/src/com/ibm/safr/we/ui/editors/pf/PhysicalFileGeneralEditor.java
@@ -549,8 +549,7 @@ public class PhysicalFileGeneralEditor {
         int selectIdx = 0;
         int idx = 0;
         for (Code code : codeList) {
-            if (code.getGeneralId().equals(Codes.DB2VIASQL) ||
-                code.getGeneralId().equals(Codes.DB2VIAVSAM)) {
+            if (code.getGeneralId().equals(Codes.DB2VIASQL)) {
                 comboGeneralAccessMethod.add(code.getDescription());
                 comboGeneralAccessMethod.setData(Integer.toString(idx), code);
                 if (code.equals(physicalFile.getAccessMethodCode())) {

--- a/plugins/genevagui/src/com/ibm/safr/we/ui/editors/pf/PhysicalFileMediator.java
+++ b/plugins/genevagui/src/com/ibm/safr/we/ui/editors/pf/PhysicalFileMediator.java
@@ -168,8 +168,4 @@ public class PhysicalFileMediator {
         physicalFileDatabaseEditor.enableSQL();
     }
 
-    public void enableVSAM() {
-        physicalFileDatabaseEditor.enableVSAM();
-    }
-
 }


### PR DESCRIPTION
1. We are now allowing Zoned Decimal data items to be up to 31 digits in length. Modify the Workbench wherever the length of Zoned Decimal items is checks (for example, in the LR Fields screen).
2. We have decided that the "DB2 via VSAM" feature is too risky to retain, so we will remove it from the Workbench based on the new PF layout.